### PR TITLE
display dates in the site's timezone

### DIFF
--- a/elementtypes/AuditLogElementType.php
+++ b/elementtypes/AuditLogElementType.php
@@ -113,7 +113,9 @@ class AuditLogElementType extends BaseElementType
             // Format dates
             case 'dateCreated':
             case 'dateUpdated':
-                return craft()->dateFormatter->formatDateTime($element->$attribute);
+                $dt = new DateTime(craft()->dateFormatter->formatDateTime($element->$attribute));
+                
+                return $dt->format('d M Y H:i:s');
 
             // Return clickable user link
             case 'user':

--- a/templates/_log.twig
+++ b/templates/_log.twig
@@ -43,7 +43,7 @@
                     {{ item.origin }}
                 </td>
                 <td data-title="{{ 'Modified'|t }}">
-                    {{ item.dateUpdated|datetime }}
+                    {{ item.dateUpdated|date('d M Y H:i:s') }}
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
Hi,

I've noticed that the dates like dateCreated or DateUpdated where shown like they are stored in the database (UTC). So I added some logic to show the dates in the site's timezone instead.